### PR TITLE
NOUPSTREAM: deb-pkg: add bindeb-pkg as an alias

### DIFF
--- a/scripts/package/Makefile
+++ b/scripts/package/Makefile
@@ -86,6 +86,7 @@ quiet_cmd_builddeb = BUILDDEB
 	$$KBUILD_PKG_ROOTCMD $(CONFIG_SHELL) \
 		$(srctree)/scripts/package/builddeb
 
+bindeb-pkg : deb-pkg
 deb-pkg: FORCE
 	$(MAKE) KBUILD_SRC=
 	$(call cmd,builddeb)


### PR DESCRIPTION
We are currently getting build failures because other code is starting
to use bindeb-pkg which was introduced in v4.1 by 3716001bcb7f
("deb-pkg: add source package").

Whilst this could be backported it requires some effort to disentangle
it from other related changes. For that reason I've taken a simpler
approach of aliasing bindeb-pkg and deb-pkg. This is OK because
bindeb-pkg in v4.1+ does the same thing that deb-pkg does in v3.10
anyway.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>